### PR TITLE
Fix broken links to GOVERNANCE.md and CHANGELOG.md on documentation site

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -14,8 +14,8 @@
 
 - [Whitepaper](./WHITEPAPER.md)
 - [System Architecture](./ARCHITECTURE.md)
-- [Governance](../cillar/GOVERNANCE.md)
-- [Changelog](../cillar/CHANGELOG.md)
+- [Governance](./cillar/GOVERNANCE.md)
+- [Changelog](./cillar/CHANGELOG.md)
 
 <!-- Coming Soon:
 - [Smart Contract](./contracts/CillarCoin.sol)


### PR DESCRIPTION
This update resolves broken links on the GitHub Pages site by ensuring that both GOVERNANCE.md and CHANGELOG.md are correctly referenced from the index.md file. The markdown links were updated to point to the correct file locations so they are accessible in the rendered documentation site. This improves navigation and ensures all governance and changelog resources are available to visitors.